### PR TITLE
Added a new template to 12.1 to help generate the correct code for multi-type properties in the designer.

### DIFF
--- a/Sitefinity CLI/Templates/12.1/CustomWidget/MultiTypeProp/Controller.Template
+++ b/Sitefinity CLI/Templates/12.1/CustomWidget/MultiTypeProp/Controller.Template
@@ -1,0 +1,46 @@
+﻿/* {{> sign}} */
+
+using SitefinityWebApp.Mvc.Models;
+using System;
+using System.Web.Mvc;
+using Telerik.Sitefinity.Mvc;
+using Telerik.Sitefinity.Personalization;
+
+namespace SitefinityWebApp.Mvc.Controllers
+{
+	public enum Enumeration
+    {
+        Value1,
+        Value2,
+        Value3
+    }
+
+	[ControllerToolboxItem(Name = "{{pascalCaseName}}_MVC", Title = "{{name}}", SectionName = "CustomWidgets")]
+	public class {{pascalCaseName}}Controller : Controller, IPersonalizable
+	{
+		// GET: {{name}}
+		public ActionResult Index()
+		{
+			var model = new {{pascalCaseName}}Model()
+			{
+                Message = this.Message,
+                Number = this.Number,
+                Check = this.Check,
+                MyDate = this.MyDate,
+                MyEnum = this.MyEnum
+            };
+			return View(model);
+		}
+		
+        protected override void HandleUnknownAction(string actionName)
+        {
+            this.ActionInvoker.InvokeAction(this.ControllerContext, "Index");
+        }
+
+		public string Message { get; set; }
+		public int Number {get; set; }
+		public bool Check {get; set; }
+        public DateTime? MyDate { get; set; }
+        public Enumeration MyEnum { get; set; }
+	}
+}

--- a/Sitefinity CLI/Templates/12.1/CustomWidget/MultiTypeProp/Designer.Template
+++ b/Sitefinity CLI/Templates/12.1/CustomWidget/MultiTypeProp/Designer.Template
@@ -1,0 +1,71 @@
+﻿/* {{> sign}} */
+
+var designerModule = angular.module('designer');
+designerModule.requires.push('sfSelectors');
+
+designerModule.directive('stringToInt', function () {
+    return {
+        require: 'ngModel',
+        link: function (scope, element, attrs, ngModel) {
+            ngModel.$parsers.push(function (value) {
+                return parseInt(value);
+            });
+            ngModel.$formatters.push(function (value) {
+                return parseInt(value);
+            });
+        }
+    };
+})
+    .directive('stringToBool', function () {
+        return {
+            require: 'ngModel',
+            link: function (scope, element, attrs, ngModel) {
+                ngModel.$parsers.push(function (value) {
+                    var returnValue = false;
+                    if (value) {
+                        if (value === true || value === 'true') {
+                            returnValue = true;
+                        }
+                    }
+                    return returnValue;
+                });
+                ngModel.$formatters.push(function (value) {
+                    var retValue = false;
+                    if (value !== undefined && value === 'True') {
+                        retValue = true;
+                    }
+                    return retValue;
+                });
+            }
+        };
+    })
+designerModule.controller('SimpleCtrl', ['$scope', 'propertyService', function ($scope, propertyService) {
+    $scope.feedback.showLoadingIndicator = true;
+
+    propertyService.get()
+        .then(function (data) {
+            if (data) {
+                $scope.properties = propertyService.toAssociativeArray(data.Items);
+            }
+        },
+            function (data) {
+                $scope.feedback.showError = true;
+                if (data)
+                    $scope.feedback.errorMessage = data.Detail;
+            })
+        .finally(function () {
+            $scope.feedback.showLoadingIndicator = false;
+        });
+
+    $scope.$watch('properties.MyDate.PropertyValue', function (newValue, oldValue) {
+        if (newValue) {
+            $scope.date = new Date(newValue);
+        }
+    }, true);
+
+    $scope.$watch('date', function (newValue, oldValue) {
+        if (newValue) {
+            $scope.properties.MyDate.PropertyValue = newValue.toUTCString();
+        }
+    }, true);
+}]);

--- a/Sitefinity CLI/Templates/12.1/CustomWidget/MultiTypeProp/DesignerView.Template
+++ b/Sitefinity CLI/Templates/12.1/CustomWidget/MultiTypeProp/DesignerView.Template
@@ -1,0 +1,25 @@
+﻿@* {{> sign}} *@
+
+<div>
+    <label>Your New Message: </label>
+    <input type="text" ng-model="properties.Message.PropertyValue" />
+</div>
+<div>
+    <label>Your New Number: </label>
+    <input type="number" string-to-int ng-model="properties.Number.PropertyValue" />
+</div>
+<div>
+    <label>Your New Check: </label>
+    <input type="checkbox" string-to-bool ng-model="properties.Check.PropertyValue" />
+</div>
+
+<sf-date-time-picker ng-model="date" sf-show-meridian="true" sf-hour-step="1" sf-minute-step="5"></sf-date-time-picker>
+
+<p>
+    <label for="enum">Enum</label>
+    <select id="enum" ng-model="properties.MyEnum.PropertyValue">
+        <option value="Value1">Value 1</option>
+        <option value="Value2">Value 2</option>
+        <option value="Value3">Value 3</option>
+    </select>
+</p>

--- a/Sitefinity CLI/Templates/12.1/CustomWidget/MultiTypeProp/DesignerViewJ.Template
+++ b/Sitefinity CLI/Templates/12.1/CustomWidget/MultiTypeProp/DesignerViewJ.Template
@@ -1,0 +1,4 @@
+{
+	"priority": 1,
+	"components" : ["sf-date-time-picker"]
+}

--- a/Sitefinity CLI/Templates/12.1/CustomWidget/MultiTypeProp/Model.Template
+++ b/Sitefinity CLI/Templates/12.1/CustomWidget/MultiTypeProp/Model.Template
@@ -1,0 +1,19 @@
+﻿/* {{> sign}} */
+
+using System.Web.Mvc;
+using SitefinityWebApp.Mvc.Controllers;
+using System;
+
+using Telerik.Sitefinity.Mvc;
+
+namespace SitefinityWebApp.Mvc.Models
+{
+	public class {{pascalCaseName}}Model
+	{
+		public string Message { get; set; }
+		public int Number {get; set; }
+		public bool Check {get; set; }
+        public DateTime? MyDate { get; set; }
+        public Enumeration MyEnum { get; set; }
+	}
+}

--- a/Sitefinity CLI/Templates/12.1/CustomWidget/MultiTypeProp/View.Template
+++ b/Sitefinity CLI/Templates/12.1/CustomWidget/MultiTypeProp/View.Template
@@ -1,0 +1,24 @@
+﻿@* {{> sign}} *@
+
+@model SitefinityWebApp.Mvc.Models.{{pascalCaseName}}Model
+<div>
+    @Model.Message
+</div>
+<div>
+    @Model.Number
+</div>
+<div>
+    @Model.Check
+</div>
+<div>
+    @Model.MyEnum
+</div>
+
+@if (Model.MyDate.HasValue)
+{
+    <div>@Model.MyDate.Value.ToString("F")</div>
+}
+else
+{
+    <div style="color: red;">Please select a date!</div>
+}

--- a/Sitefinity CLI/Templates/12.1/CustomWidget/MultiTypeProp/templates.json
+++ b/Sitefinity CLI/Templates/12.1/CustomWidget/MultiTypeProp/templates.json
@@ -1,0 +1,26 @@
+﻿[
+  {
+    "FilePath": "Controllers\\{0}Controller.cs",
+    "TemplatePath": "Controller.Template"
+  },
+  {
+    "FilePath": "Models\\{0}Model.cs",
+    "TemplatePath": "Model.Template"
+  },
+  {
+    "FilePath": "Views\\{0}\\Index.cshtml",
+    "TemplatePath": "View.Template"
+  },
+  {
+    "FilePath": "Scripts\\{0}\\designerview-simple.js",
+    "TemplatePath": "Designer.Template"
+  },
+  {
+    "FilePath": "Views\\{0}\\DesignerView.Simple.cshtml",
+    "TemplatePath": "DesignerView.Template"
+  },
+  {
+    "FilePath": "Views\\{0}\\DesignerView.Simple.json",
+    "TemplatePath": "DesignerViewJ.Template"
+  }
+]

--- a/Sitefinity CLI/Templates/12.1/CustomWidget/Readme.md
+++ b/Sitefinity CLI/Templates/12.1/CustomWidget/Readme.md
@@ -1,0 +1,20 @@
+# Custom Widget Templates
+
+## Default will create the necessary files under the MVC folder for a widget that has ONE property of type String in the Model and Controller to help with the creation of the boiler plate generated code needed for the all aspects of getting the Widget to work and function correctly
+
+### files created for default template:
+- Model/{widget}model.cs
+- Controllers/{widget}controller.cs
+- Scripts/{widget}/designer-view-simple.js
+- Views/{widget}/index.cshtml
+- Views/{widget}/DesignerView.Simple.cshtml
+
+## MultiTypeProp will create the necessary files under the MVC folder in order to implement several properties of type string, integer, boolean, datetime and enum. This template will generate the code needed for the AngularJS application to persist the value of these properties in the custom designer.  It will also add the proper components in the json file to allow for the KendoUI DateTime Picker to display correctly inthe designer.
+
+### files created for MultiTypeProp template:
+- Model/{widget}model.cs
+- Controllers/{widget}controller.cs
+- Scripts/{widget}/designer-view-simple.js
+- Views/{widget}/index.cshtml
+- Views/{widget}/DesignerView.Simple.cshtml
+- Views/{widget}/DesignerView.Simple.json

--- a/Sitefinity CLI/Templates/12.1/CustomWidget/Readme.md
+++ b/Sitefinity CLI/Templates/12.1/CustomWidget/Readme.md
@@ -1,6 +1,6 @@
 # Custom Widget Templates
 
-## Default will create the necessary files under the MVC folder for a widget that has ONE property of type String in the Model and Controller to help with the creation of the boiler plate generated code needed for the all aspects of getting the Widget to work and function correctly
+### Default will create the necessary files under the MVC folder for a widget that has ONE property of type String in the Model and Controller to help with the creation of the boiler plate generated code needed for the all aspects of getting the Widget to work and function correctly
 
 ### files created for default template:
 - Model/{widget}model.cs
@@ -9,7 +9,7 @@
 - Views/{widget}/index.cshtml
 - Views/{widget}/DesignerView.Simple.cshtml
 
-## MultiTypeProp will create the necessary files under the MVC folder in order to implement several properties of type string, integer, boolean, datetime and enum. This template will generate the code needed for the AngularJS application to persist the value of these properties in the custom designer.  It will also add the proper components in the json file to allow for the KendoUI DateTime Picker to display correctly inthe designer.
+### MultiTypeProp will create the necessary files under the MVC folder in order to implement several properties of type string, integer, boolean, datetime and enum. This template will generate the code needed for the AngularJS application to persist the value of these properties in the custom designer.  It will also add the proper components in the json file to allow for the KendoUI DateTime Picker to display correctly inthe designer.
 
 ### files created for MultiTypeProp template:
 - Model/{widget}model.cs


### PR DESCRIPTION
This template can also be added to other versions of Sitefinity starting by 10.0

This will fix the issue of not being able to persist properties other than strings in the designers and customers can copy and paste the code from the designerview-simple.js in their own widgets to get around the issue.