### PR TITLE
Add Retry Logic when launching Visual Studio

### DIFF
--- a/Sitefinity CLI/PackageManagement/Implementations/VisualStudioWorker.cs
+++ b/Sitefinity CLI/PackageManagement/Implementations/VisualStudioWorker.cs
@@ -39,7 +39,7 @@ namespace Sitefinity_CLI.PackageManagement.Implementations
 
             int maxRetries = 5;
             int retryDelayMs = 60000;
-            object obj;
+            object obj = new object();
 
             for (int attempt = 1; attempt <= maxRetries; attempt++)
             {

--- a/Sitefinity CLI/Sitefinity CLI.csproj
+++ b/Sitefinity CLI/Sitefinity CLI.csproj
@@ -5,9 +5,9 @@
     <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>sf</AssemblyName>
     <RootNamespace>Sitefinity_CLI</RootNamespace>
-    <AssemblyVersion>1.1.0.58</AssemblyVersion>
+    <AssemblyVersion>1.1.0.63</AssemblyVersion>
     <Version>1.1.0</Version>
-    <FileVersion>1.1.0.58</FileVersion>
+    <FileVersion>1.1.0.63</FileVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>


### PR DESCRIPTION
Occasionally, when launching Visual Studio it may throw a COM exception due to not being ready. 
`fail: Error during ***: Retrieving the COM class factory for component with CLSID {2E1517DA-87BF-4443-984A-D2BF18F5A908} failed due to the following error: 80080005 Server execution failed (0x80080005 (CO_E_SERVER_EXEC_FAILURE)).
`
Add a retry logic to avoid running the command multiple times.