### PR TITLE
Add support for printing the CLI version

### DIFF
--- a/Sitefinity CLI/Commands/VersionCommand.cs
+++ b/Sitefinity CLI/Commands/VersionCommand.cs
@@ -1,0 +1,27 @@
+﻿using McMaster.Extensions.CommandLineUtils;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+
+namespace Sitefinity_CLI.Commands
+{
+    [HelpOption]
+    [Command(Constants.VersionCommandName, Description = "Show the version of Sitefinity CLI")]
+    internal class VersionCommand(ILogger<VersionCommand> logger)
+    {
+        protected async Task<int> OnExecuteAsync(CommandLineApplication app)
+        {
+            try
+            {
+                var version = typeof(VersionCommand).Assembly.GetName().Version;
+                logger.LogInformation($"Sitefinity CLI version {version}");
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex.Message);
+                return 1;
+            }
+        }
+    }
+}

--- a/Sitefinity CLI/Constants.cs
+++ b/Sitefinity CLI/Constants.cs
@@ -189,6 +189,7 @@ namespace Sitefinity_CLI
         public const string UpgradeCommandName = "upgrade";
         public const string CreateCommandName = "create";
         public const string MigrateCommandName = "migrate";
+        public const string VersionCommandName = "version";
 
         public const string DefaultResourcePackageName_VersionsBefore14_1 = "Bootstrap4";
         public const string DefaultResourcePackageName = "Bootstrap5";

--- a/Sitefinity CLI/Program.cs
+++ b/Sitefinity CLI/Program.cs
@@ -28,6 +28,7 @@ namespace Sitefinity_CLI
     [Subcommand(typeof(CreateCommand))]
     [Subcommand(typeof(GenerateConfigCommand))]
     [Subcommand(typeof(MigrateCommand))]
+    [Subcommand(typeof(VersionCommand))]
     public class Program
     {
         internal delegate INugetProvider NugetProviderFactory(ProtocolVersion version);


### PR DESCRIPTION
Add the `version` command to print the version of the CLI.