### PR TITLE
fix: correct three typos in VisualStudioService error log message

### DIFF
--- a/Sitefinity CLI/Services/VisualStudioService.cs
+++ b/Sitefinity CLI/Services/VisualStudioService.cs
@@ -98,7 +98,7 @@ namespace Sitefinity_CLI.Services
                 string result = this.ReadAllTextFromFile(resultFile);
                 if (result != SuccessIndicator)
                 {
-                    this.logger.LogError("Error occured while executin visual stuido command {Message}", result);
+                    this.logger.LogError("Error occurred while executing visual studio command {Message}", result);
                     throw new VisualStudioCommandException("Operation failed");
                 }
 


### PR DESCRIPTION
## Summary

Fixes #383

Three typos in the error log message on line 101 of `Sitefinity CLI/Services/VisualStudioService.cs`:

| Before | After |
|--------|-------|
| `occured` | `occurred` |
| `executin` | `executing` |
| `stuido` | `studio` |

**Before:** `"Error occured while executin visual stuido command {Message}"`
**After:** `"Error occurred while executing visual studio command {Message}"`