### PR TITLE
Decompose Sitefinity.All upgrades to avoid large NuGet txns

### DIFF
--- a/Sitefinity CLI/PackageManagement/Implementations/UpgradeConfigGenerator.cs
+++ b/Sitefinity CLI/PackageManagement/Implementations/UpgradeConfigGenerator.cs
@@ -88,9 +88,28 @@ namespace Sitefinity_CLI.PackageManagement.Implementations
             }
 
             this.processedPackagesPerProjectCache[projectFilePath] = new HashSet<string>();
-            if (!this.TryAddPackageTreeToProjectUpgradeConfigSection(powerShellXmlConfig, projectNode, projectFilePath, currentSitefinityVersionPackageTree, newSitefinityVersionPackageTree))
+
+            bool isMetaPackageDecomposed = this.ShouldDecomposePackage(currentSitefinityVersionPackageTree.Id);
+            if (isMetaPackageDecomposed)
+            {
+                this.logger.LogInformation($"Decomposing '{currentSitefinityVersionPackageTree.Id}' into individual dependency updates to avoid large NuGet transactions.");
+                await this.ProcessPackagesForProjectUpgradeConfigSection(powerShellXmlConfig, projectNode, projectFilePath, currentSitefinityVersionPackageTree.Dependencies, newSitefinityVersionPackageTree);
+            }
+            else if (!this.TryAddPackageTreeToProjectUpgradeConfigSection(powerShellXmlConfig, projectNode, projectFilePath, currentSitefinityVersionPackageTree, newSitefinityVersionPackageTree))
             {
                 await this.ProcessPackagesForProjectUpgradeConfigSection(powerShellXmlConfig, projectNode, projectFilePath, currentSitefinityVersionPackageTree.Dependencies, newSitefinityVersionPackageTree);
+            }
+
+            // Add the decomposed meta-package as the last entry with ignoreDependencies flag
+            // so its version in packages.config is updated without re-processing all dependencies
+            if (isMetaPackageDecomposed)
+            {
+                NuGetPackage newMetaPackage = this.FindNuGetPackageByIdInDependencyTree(newSitefinityVersionPackageTree, currentSitefinityVersionPackageTree.Id);
+                if (newMetaPackage != null)
+                {
+                    this.AddPackageNodeToProjectUpgradeConfigSection(powerShellXmlConfig, projectNode, newMetaPackage, ignoreDependencies: true);
+                    this.processedPackagesPerProjectCache[projectFilePath].Add(newMetaPackage.Id);
+                }
             }
 
             foreach (NuGetPackage additionalPackage in additionalPackagesToUpgrade)
@@ -145,7 +164,7 @@ namespace Sitefinity_CLI.PackageManagement.Implementations
             return true;
         }
 
-        private void AddPackageNodeToProjectUpgradeConfigSection(XmlDocument powerShellXmlConfig, XmlElement projectNode, NuGetPackage nuGetPackage)
+        private void AddPackageNodeToProjectUpgradeConfigSection(XmlDocument powerShellXmlConfig, XmlElement projectNode, NuGetPackage nuGetPackage, bool ignoreDependencies = false)
         {
             XmlElement packageNode = powerShellXmlConfig.CreateElement("package");
             XmlAttribute nameAttribute = powerShellXmlConfig.CreateAttribute("name");
@@ -154,6 +173,14 @@ namespace Sitefinity_CLI.PackageManagement.Implementations
             versionAttribute.Value = nuGetPackage.Version;
             packageNode.Attributes.Append(nameAttribute);
             packageNode.Attributes.Append(versionAttribute);
+
+            if (ignoreDependencies)
+            {
+                XmlAttribute ignoreDepsAttribute = powerShellXmlConfig.CreateAttribute("ignoreDependencies");
+                ignoreDepsAttribute.Value = "true";
+                packageNode.Attributes.Append(ignoreDepsAttribute);
+            }
+
             projectNode.AppendChild(packageNode);
         }
 
@@ -187,6 +214,11 @@ namespace Sitefinity_CLI.PackageManagement.Implementations
             }
 
             return null;
+        }
+
+        private bool ShouldDecomposePackage(string packageId)
+        {
+            return packageId.Equals(Constants.SitefinityAllNuGetPackageId, StringComparison.OrdinalIgnoreCase);
         }
 
         private readonly ILogger logger;

--- a/Sitefinity CLI/PowerShell/Updater.ps1
+++ b/Sitefinity CLI/PowerShell/Updater.ps1
@@ -77,7 +77,13 @@ try {
                 if ($isUpdateRequired) {
                     "`nUpgrading from '$oldPackageVersion' to '$packageVersion'"
                     $errorMessage = $null;
-                    Invoke-Expression "Update-Package -Id $packageName -ProjectName `"$projectName`" -Version $packageVersion -FileConflictAction OverwriteAll -IncludePrerelease -ErrorVariable errorMessage" 
+                    $ignoreDeps = $package.ignoreDependencies -eq "true"
+                    $updateCmd = "Update-Package -Id $packageName -ProjectName `"$projectName`" -Version $packageVersion -FileConflictAction OverwriteAll -IncludePrerelease"
+                    if ($ignoreDeps) {
+                        $updateCmd += " -IgnoreDependencies"
+                        "`nUsing -IgnoreDependencies for '$packageName' (dependencies already updated individually)"
+                    }
+                    Invoke-Expression "$updateCmd -ErrorVariable errorMessage" 
 					
                     if ($errorMessage -ne $null) {
                         Write-Error -Message "`nError occured while upgrading $packageName. The error was: $errorMessage" -ErrorAction Stop

--- a/Sitefinity CLI/Sitefinity CLI.csproj
+++ b/Sitefinity CLI/Sitefinity CLI.csproj
@@ -4,9 +4,9 @@
     <TargetFramework>net9.0</TargetFramework>
     <AssemblyName>sf</AssemblyName>
     <RootNamespace>Sitefinity_CLI</RootNamespace>
-    <AssemblyVersion>1.1.0.82</AssemblyVersion>
+    <AssemblyVersion>1.1.0.83</AssemblyVersion>
     <Version>1.1.0</Version>
-    <FileVersion>1.1.0.82</FileVersion>
+    <FileVersion>1.1.0.83</FileVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>


### PR DESCRIPTION
UpgradeConfigGenerator now decomposes "Sitefinity.All" meta-package upgrades into individual dependency updates, then updates the meta-package with ignoreDependencies to prevent redundant dependency processing. Added support for ignoreDependencies in XML and PowerShell, ensuring -IgnoreDependencies is used during package update when needed.